### PR TITLE
Add documentation to .travis.yml command re use of Skelly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
 sudo: required
 before_script:
 - npm install -g skelly
-script: skelly build
+script: skelly build  # This will create a new folder `converted-html` containing demo site static files that have been compiled by Skelly.
 after_success:
 - echo styles.iatistandard.org > converted-html/CNAME
 deploy:


### PR DESCRIPTION
Adds a line of documentation describing how Skelly creates the `converted-html` containing compiled static files.