### PR TITLE
Make use of custom domain (via CNAME file) clearer in VCS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_script:
 - npm install -g skelly
 script: skelly build
 after_success:
-- echo styles.iatistandard.org > converted-html/CNAME
+- mv CNAME converted-html/CNAME  # Moves the definition of the custom domain name to the folder containing static output files (ahead of deployment to Github Pages).
 deploy:
   provider: pages
   local-dir: converted-html

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+styles.iatistandard.org


### PR DESCRIPTION
Removes creation of CNAME file out of .travis.yml and expilcitly defines in at the root of the repo. Under this approach, .travis.yml simply moves it from the root of the repo to the output folder.